### PR TITLE
Fixes end of input errors

### DIFF
--- a/lib/xkcd.ex
+++ b/lib/xkcd.ex
@@ -2,9 +2,10 @@ defmodule Xkcd do
   @moduledoc """
   A client for the XKCD JSON API
   """
-
   alias Xkcd.Comic
   alias HTTPoison.Response
+
+  @base_url "https://xkcd.com"
 
   @doc """
   Takes a number from 1 to the latest and returns a tuple with with :ok and a
@@ -21,7 +22,7 @@ defmodule Xkcd do
   @spec number(integer) :: {:ok, Comic.t}
                          | {:error, String.t}
   def number(integer) do
-    "http://xkcd.com/#{integer}/info.0.json"
+    "#{@base_url}/#{integer}/info.0.json"
     |> get_comic
   end
 
@@ -36,7 +37,7 @@ defmodule Xkcd do
   """
   @spec latest :: {:ok, Comic.t}
   def latest do
-    "http://xkcd.com/info.0.json"
+    "#{@base_url}/info.0.json"
     |> get_comic
   end
 
@@ -58,7 +59,7 @@ defmodule Xkcd do
 
   defp get_comic(url) do
     url
-    |> HTTPoison.get
+    |> HTTPoison.get([], follow_redirect: true)
     |> get_body
     |> parse_body
   end

--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule Xkcd.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "Uses the XKCD JSON API to retrieve the random, specific and the latest XKCD comic.",
-     package: package,
-     deps: deps,
+     package: package(),
+     deps: deps(),
      docs: [extras: ["README.md"]]]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Xkcd.Mixfile do
 
   def project do
     [app: :xkcd,
-     version: "0.0.1",
+     version: "0.0.2",
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
-%{"certifi": {:hex, :certifi, "0.3.0"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"},
-  "hackney": {:hex, :hackney, "1.4.10"},
-  "httpoison": {:hex, :httpoison, "0.8.1"},
-  "idna": {:hex, :idna, "1.1.0"},
-  "mimerl": {:hex, :mimerl, "1.0.2"},
-  "poison": {:hex, :poison, "2.1.0"},
-  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"}}
+%{"certifi": {:hex, :certifi, "0.3.0", "389d4b126a47895fe96d65fcf8681f4d09eca1153dc2243ed6babad0aac1e763", [:rebar3], []},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "hackney": {:hex, :hackney, "1.4.10", "7da877a7388a8bcc7d71253d4a38103c955333dd470a3af5e47fa1ad8d5e3c23", [:rebar3], [{:certifi, "0.3.0", [hex: :certifi, optional: false]}, {:idna, "1.1.0", [hex: :idna, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_hostname, "1.0.5", [hex: :ssl_verify_hostname, optional: false]}]},
+  "httpoison": {:hex, :httpoison, "0.8.1", "5b706be2b0af81d1a3870479a2e1b925517c2a64316f70c6cc8aceac9e55f695", [:mix], [{:hackney, "~> 1.4.4", [hex: :hackney, optional: false]}]},
+  "idna": {:hex, :idna, "1.1.0", "b4315c6da1c37dc8ab1df3ed18796ecd5172c4165fb886f43732ce598d145b50", [:rebar3], []},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []}}


### PR DESCRIPTION
HTTPoison doesn't follow redirects by default and xkcd changed their api to
use https. This fixes the problem by both updating the base url and telling
httpoison to follow redirects.